### PR TITLE
Feature/hamming

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -27,8 +27,14 @@ class TextProcessor:
         # 2-3
         pass
 
-    def hamming(self, x: int, y: int) -> int:
-
+    @staticmethod
+    def hamming(x: str, y: str) -> int:
+        distance = 0
+        for i in range(31, -1, -1):
+            x_bit = int(x, 2) >> i & 1
+            y_bit = int(y, 2) >> i & 1
+            distance += not (x_bit == y_bit)
+        return distance
         pass
 
 

--- a/utils.py
+++ b/utils.py
@@ -28,7 +28,7 @@ class TextProcessor:
         pass
 
     def hamming(self, x: int, y: int) -> int:
-        # 2-4
+
         pass
 
 


### PR DESCRIPTION
change signature because 
1) for e.g. we can't give '001' to method as input and we should cast it to 1 so I prefer use strings for more flexibility 
2) I used binary cast in method that gives string as input parameter